### PR TITLE
Uses buildpack.toml config in integration suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/paketo-buildpacks/yarn-install
 go 1.13
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/onsi/gomega v1.10.1
 	github.com/paketo-buildpacks/occam v0.0.12
 	github.com/paketo-buildpacks/packit v0.0.14

--- a/integration/caching_test.go
+++ b/integration/caching_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -62,7 +63,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 				imageIDs[firstImage.ID] = struct{}{}
 
 				Expect(firstImage.Buildpacks).To(HaveLen(2))
-				Expect(firstImage.Buildpacks[1].Key).To(Equal("paketo-buildpacks/yarn-install"))
+				Expect(firstImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 				Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("yarn"))
 				Expect(firstImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
@@ -79,7 +80,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 				imageIDs[secondImage.ID] = struct{}{}
 
 				Expect(secondImage.Buildpacks).To(HaveLen(2))
-				Expect(secondImage.Buildpacks[1].Key).To(Equal("paketo-buildpacks/yarn-install"))
+				Expect(secondImage.Buildpacks[1].Key).To(Equal(buildpackInfo.Buildpack.ID))
 				Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("yarn"))
 				Expect(secondImage.Buildpacks[1].Layers).To(HaveKey("modules"))
 
@@ -102,8 +103,8 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(secondLogs).To(ContainLines(
-					fmt.Sprintf("Yarn Install Buildpack %s", buildpackVersion),
-					"  Reusing cached layer /layers/paketo-buildpacks_yarn-install/yarn",
+					fmt.Sprintf("%s %s", buildpackInfo.Buildpack.Name, buildpackVersion),
+					fmt.Sprintf("  Reusing cached layer /layers/%s/yarn", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 					"",
 					"  Resolving installation process",
 					"    Process inputs:",
@@ -111,7 +112,7 @@ func testCaching(t *testing.T, context spec.G, it spec.S) {
 					"",
 					"    Selected default build process: 'yarn install'",
 					"",
-					"  Reusing cached layer /layers/paketo-buildpacks_yarn-install/modules",
+					fmt.Sprintf("  Reusing cached layer /layers/%s/modules", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				))
 			})
 		})

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/paketo-buildpacks/occam"
 	"github.com/paketo-buildpacks/packit/pexec"
 	"github.com/sclevine/spec"
@@ -22,6 +23,12 @@ var (
 	yarnCachedURI string
 	nodeURI       string
 	nodeCachedURI string
+	buildpackInfo struct {
+		Buildpack struct {
+			ID   string
+			Name string
+		}
+	}
 )
 
 func TestIntegration(t *testing.T) {
@@ -37,6 +44,12 @@ func TestIntegration(t *testing.T) {
 	Expect(json.NewDecoder(file).Decode(&config)).To(Succeed())
 
 	root, err := filepath.Abs("./..")
+	Expect(err).NotTo(HaveOccurred())
+
+	file, err = os.Open("../buildpack.toml")
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = toml.DecodeReader(file, &buildpackInfo)
 	Expect(err).NotTo(HaveOccurred())
 
 	buildpackStore := occam.NewBuildpackStore()

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -56,7 +57,7 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("Yarn Install Buildpack %s", buildpackVersion),
+				fmt.Sprintf("%s %s", buildpackInfo.Buildpack.Name, buildpackVersion),
 				"  Executing build process",
 				MatchRegexp(`    Installing Yarn 1\.\d+\.\d+`),
 				MatchRegexp(`      Completed in (\d+)(\.\d+)?(ms|s)`),
@@ -68,11 +69,11 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				"    Selected default build process: 'yarn install'",
 				"",
 				"  Executing build process",
-				"    Running yarn install --ignore-engines --frozen-lockfile --modules-folder /layers/paketo-buildpacks_yarn-install/modules/node_modules",
+				fmt.Sprintf("    Running yarn install --ignore-engines --frozen-lockfile --modules-folder /layers/%s/modules/node_modules", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in (\d+)(\.\d+)?(ms|s)`),
 				"",
 				"  Configuring environment",
-				`    PATH -> "$PATH:/layers/paketo-buildpacks_yarn-install/modules/node_modules/.bin"`,
+				fmt.Sprintf(`    PATH -> "$PATH:/layers/%s/modules/node_modules/.bin"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
 		})
 	})
@@ -108,7 +109,7 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("Yarn Install Buildpack %s", buildpackVersion),
+				fmt.Sprintf("%s %s", buildpackInfo.Buildpack.Name, buildpackVersion),
 				"  Executing build process",
 				MatchRegexp(`    Installing Yarn 1\.\d+\.\d+`),
 				MatchRegexp(`      Completed in (\d+)(\.\d+)?(ms|s)`),
@@ -120,11 +121,11 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				"    Selected default build process: 'yarn install'",
 				"",
 				"  Executing build process",
-				"    Running yarn install --ignore-engines --frozen-lockfile --offline --modules-folder /layers/paketo-buildpacks_yarn-install/modules/node_modules",
+				fmt.Sprintf("    Running yarn install --ignore-engines --frozen-lockfile --offline --modules-folder /layers/%s/modules/node_modules", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in (\d+)(\.\d+)?(ms|s)`),
 				"",
 				"  Configuring environment",
-				`    PATH -> "$PATH:/layers/paketo-buildpacks_yarn-install/modules/node_modules/.bin"`,
+				fmt.Sprintf(`    PATH -> "$PATH:/layers/%s/modules/node_modules/.bin"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
 		})
 	})


### PR DESCRIPTION
Instead of hardcoding these values, we are parameterizing them and reading them from the buildpack.toml so that if they change, the test suite does not need to change.