### PR TITLE
feat: add Yarn Berry (v2+) support with automatic version switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The Yarn Install CNB generates and provides application dependencies for node
 applications that use the [yarn](https://yarnpkg.com) package manager.
 
-**NOTE:** Support for `yarn` is limited to version 1 (Classic).
+Supports both **Yarn Classic (v1)** and **Yarn Berry (v2+)**.
 
 ## Integration
 
@@ -63,6 +63,27 @@ the `BP_NODE_PROJECT_PATH` environment variable at build time either directly
 [`project.toml`
 file](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md).
 This could be useful if your app is a part of a monorepo.
+
+## Yarn Classic vs Yarn Berry
+
+The install process is selected automatically based on the `packageManager` field
+in `package.json`:
+
+| `packageManager` value | Install process |
+| :--- | :--- |
+| `yarn@1.x.x` or absent | Classic: `yarn install --frozen-lockfile` |
+| `yarn@2.x.x` or higher | Berry: `yarn install --immutable` |
+
+### App-provided Berry binary (`yarnPath`)
+
+If the app declares `yarnPath` in `.yarnrc.yml` pointing to a committed `.cjs`
+bundle (e.g. `.yarn/releases/yarn-4.12.0.cjs`), that binary is invoked via
+`node <yarnPath> install --immutable`, giving the app full control over the
+Berry version.
+
+If no `yarnPath` is declared, the buildpack-delivered Berry binary (on `$PATH`
+as `yarn`) is used with `YARN_IGNORE_PATH=1` to prevent any stale `yarnPath`
+from interfering.
 
 ## Run Tests
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $ ./scripts/package.sh --version <version-number>
 
 This will create a `buildpackage.cnb` file under the `build` directory which you
 can use to build your app as follows:
+
 ```
 pack build <app-name> -p <path-to-app> -b <path/to/node-engine.cnb> -b <path/to/yarn.cnb> /
 -b build/buildpackage.cnb
@@ -69,10 +70,10 @@ This could be useful if your app is a part of a monorepo.
 The install process is selected automatically based on the `packageManager` field
 in `package.json`:
 
-| `packageManager` value | Install process |
-| :--- | :--- |
+| `packageManager` value | Install process                           |
+| :--------------------- | :---------------------------------------- |
 | `yarn@1.x.x` or absent | Classic: `yarn install --frozen-lockfile` |
-| `yarn@2.x.x` or higher | Berry: `yarn install --immutable` |
+| `yarn@2.x.x` or higher | Berry: `yarn install --immutable`         |
 
 ### App-provided Berry binary (`yarnPath`)
 
@@ -82,17 +83,18 @@ bundle (e.g. `.yarn/releases/yarn-4.12.0.cjs`), that binary is invoked via
 Berry version.
 
 If no `yarnPath` is declared, the buildpack-delivered Berry binary (on `$PATH`
-as `yarn`) is used with `YARN_IGNORE_PATH=1` to prevent any stale `yarnPath`
-from interfering.
+as `yarn`) is used.
 
 ## Run Tests
 
 To run all unit tests, run:
+
 ```
 ./scripts/unit.sh
 ```
 
 To run all integration tests, run:
+
 ```
 /scripts/integration.sh
 ```

--- a/berry_install_process.go
+++ b/berry_install_process.go
@@ -1,0 +1,202 @@
+package yarninstall
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/paketo-buildpacks/packit/v2/fs"
+	"github.com/paketo-buildpacks/packit/v2/pexec"
+	"github.com/paketo-buildpacks/packit/v2/scribe"
+)
+
+// BerryInstallProcess handles `yarn install` for Yarn Berry (v2+).
+// Berry does not support --frozen-lockfile, --ignore-engines, or
+// --modules-folder; it uses --immutable instead.
+//
+// If the app commits a Berry binary and declares it via yarnPath in
+// .yarnrc.yml, that binary is invoked as `node <yarnPath>`. Otherwise the
+// buildpack-delivered @yarnpkg/cli-dist binary (on PATH as `yarn`) is used.
+type BerryInstallProcess struct {
+	yarnExecutable Executable
+	nodeExecutable Executable
+	summer         Summer
+	logger         scribe.Emitter
+}
+
+func NewBerryInstallProcess(yarnExecutable Executable, nodeExecutable Executable, summer Summer, logger scribe.Emitter) BerryInstallProcess {
+	return BerryInstallProcess{
+		yarnExecutable: yarnExecutable,
+		nodeExecutable: nodeExecutable,
+		summer:         summer,
+		logger:         logger,
+	}
+}
+
+// yarnPathFromRC reads the yarnPath value from .yarnrc.yml in workingDir.
+// Returns an empty string (no error) when .yarnrc.yml doesn't exist or has no
+// yarnPath entry — callers must treat "" as "not set".
+func yarnPathFromRC(workingDir string) (string, error) {
+	rcPath := filepath.Join(workingDir, ".yarnrc.yml")
+	f, err := os.Open(rcPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to open .yarnrc.yml: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "yarnPath:") {
+			value := strings.TrimSpace(strings.TrimPrefix(line, "yarnPath:"))
+			value = strings.Trim(value, `"'`)
+			if value == "" {
+				return "", nil
+			}
+			if filepath.IsAbs(value) {
+				return value, nil
+			}
+			return filepath.Join(workingDir, value), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read .yarnrc.yml: %w", err)
+	}
+	return "", nil
+}
+
+func (ip BerryInstallProcess) ShouldRun(workingDir string, metadata map[string]interface{}) (run bool, sha string, err error) {
+	ip.logger.Subprocess("Process inputs:")
+
+	_, err = os.Stat(filepath.Join(workingDir, "yarn.lock"))
+	if os.IsNotExist(err) {
+		ip.logger.Action("yarn.lock -> Not found")
+		ip.logger.Break()
+		return true, "", nil
+	} else if err != nil {
+		return true, "", fmt.Errorf("unable to read yarn.lock file: %w", err)
+	}
+
+	ip.logger.Action("yarn.lock -> Found")
+	ip.logger.Break()
+
+	nodeEnv := os.Getenv("NODE_ENV")
+
+	file, err := os.CreateTemp("", "berry-node-env-*")
+	if err != nil {
+		return true, "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("failed to close temp file: %w", closeErr)
+		}
+	}()
+
+	if _, writeErr := file.WriteString(nodeEnv); writeErr != nil {
+		return true, "", fmt.Errorf("failed to write temp file: %w", writeErr)
+	}
+
+	sum, err := ip.summer.Sum(filepath.Join(workingDir, "yarn.lock"), filepath.Join(workingDir, "package.json"), file.Name())
+	if err != nil {
+		return true, "", fmt.Errorf("unable to sum config files: %w", err)
+	}
+
+	prevSHA, ok := metadata["cache_sha"].(string)
+	if (ok && sum != prevSHA) || !ok {
+		return true, sum, nil
+	}
+
+	return false, "", nil
+}
+
+func (ip BerryInstallProcess) SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath string) (string, error) {
+	if currentModulesLayerPath != "" {
+		err := fs.Copy(filepath.Join(currentModulesLayerPath, "node_modules"), filepath.Join(nextModulesLayerPath, "node_modules"))
+		if err != nil {
+			return "", fmt.Errorf("failed to copy node_modules directory: %w", err)
+		}
+	} else {
+		err := os.MkdirAll(filepath.Join(nextModulesLayerPath, "node_modules"), os.ModePerm)
+		if err != nil {
+			return "", fmt.Errorf("failed to create node_modules directory: %w", err)
+		}
+	}
+	return nextModulesLayerPath, nil
+}
+
+// Execute runs `yarn install --immutable` for Yarn Berry.
+//
+// If the app declares yarnPath in .yarnrc.yml pointing to a committed .cjs
+// binary, that binary is invoked via `node <yarnPath>` — giving the app full
+// control over the Berry version. Otherwise the buildpack-delivered Berry
+// (on PATH as `yarn`) is used with YARN_IGNORE_PATH=1 to prevent any stale
+// yarnPath from interfering.
+func (ip BerryInstallProcess) Execute(workingDir, modulesLayerPath string, launch bool) error {
+	environment := os.Environ()
+	// Tell Berry to use the traditional node_modules linker.
+	environment = append(environment, "YARN_NODE_LINKER=node-modules")
+
+	// Redirect Berry's install-state cache into the layer so it survives across
+	// builds. The app is not expected to commit .yarn/install-state.gz.
+	installStateDir := filepath.Join(modulesLayerPath, ".yarn")
+	if err := os.MkdirAll(installStateDir, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create install-state directory in layer: %w", err)
+	}
+	environment = append(environment, fmt.Sprintf("YARN_INSTALL_STATE_PATH=%s", filepath.Join(installStateDir, "install-state.gz")))
+
+	if !launch {
+		environment = append(environment, "NODE_ENV=development")
+	}
+
+	// Determine which executable + args to use.
+	var exe Executable
+	var execArgs []string
+
+	yarnBin, err := yarnPathFromRC(workingDir)
+	if err != nil {
+		return fmt.Errorf("failed to read yarnPath from .yarnrc.yml: %w", err)
+	}
+
+	if yarnBin != "" {
+		// App provides its own Berry binary — invoke it via node.
+		exe = ip.nodeExecutable
+		execArgs = []string{yarnBin, "install", "--immutable"}
+		ip.logger.Subprocess("Running 'node %s install --immutable' (app-provided yarnPath)", yarnBin)
+	} else {
+		// Use the buildpack-delivered Berry; suppress any residual yarnPath.
+		environment = append(environment, "YARN_IGNORE_PATH=1")
+		exe = ip.yarnExecutable
+		execArgs = []string{"install", "--immutable"}
+		ip.logger.Subprocess("Running 'yarn install --immutable' (buildpack-provided Berry)")
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	err = exe.Execute(pexec.Execution{
+		Args:   execArgs,
+		Env:    environment,
+		Stdout: ip.logger.ActionWriter,
+		Stderr: ip.logger.ActionWriter,
+		Dir:    workingDir,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to execute yarn install: %w\n%s", err, buffer.String())
+	}
+
+	// Move node_modules from working directory into the layer so the layer can
+	// be cached and reused across builds.
+	srcNodeModules := filepath.Join(workingDir, "node_modules")
+	dstNodeModules := filepath.Join(modulesLayerPath, "node_modules")
+	if info, statErr := os.Lstat(srcNodeModules); statErr == nil && info.IsDir() {
+		if err := fs.Move(srcNodeModules, dstNodeModules); err != nil {
+			return fmt.Errorf("failed to move node_modules into layer: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/berry_install_process.go
+++ b/berry_install_process.go
@@ -2,7 +2,6 @@ package yarninstall
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -102,7 +101,18 @@ func (ip BerryInstallProcess) ShouldRun(workingDir string, metadata map[string]i
 		return true, "", fmt.Errorf("failed to write temp file: %w", writeErr)
 	}
 
-	sum, err := ip.summer.Sum(filepath.Join(workingDir, "yarn.lock"), filepath.Join(workingDir, "package.json"), file.Name())
+	pathsToSum := []string{
+		filepath.Join(workingDir, "yarn.lock"),
+		filepath.Join(workingDir, "package.json"),
+		file.Name(),
+	}
+	for _, optional := range []string{".yarnrc.yml", ".pnp.cjs", "pnp.loader.mjs"} {
+		p := filepath.Join(workingDir, optional)
+		if _, statErr := os.Stat(p); statErr == nil {
+			pathsToSum = append(pathsToSum, p)
+		}
+	}
+	sum, err := ip.summer.Sum(pathsToSum...)
 	if err != nil {
 		return true, "", fmt.Errorf("unable to sum config files: %w", err)
 	}
@@ -121,11 +131,6 @@ func (ip BerryInstallProcess) SetupModules(workingDir, currentModulesLayerPath, 
 		if err != nil {
 			return "", fmt.Errorf("failed to copy node_modules directory: %w", err)
 		}
-	} else {
-		err := os.MkdirAll(filepath.Join(nextModulesLayerPath, "node_modules"), os.ModePerm)
-		if err != nil {
-			return "", fmt.Errorf("failed to create node_modules directory: %w", err)
-		}
 	}
 	return nextModulesLayerPath, nil
 }
@@ -139,8 +144,6 @@ func (ip BerryInstallProcess) SetupModules(workingDir, currentModulesLayerPath, 
 // yarnPath from interfering.
 func (ip BerryInstallProcess) Execute(workingDir, modulesLayerPath string, launch bool) error {
 	environment := os.Environ()
-	// Tell Berry to use the traditional node_modules linker.
-	environment = append(environment, "YARN_NODE_LINKER=node-modules")
 
 	// Redirect Berry's install-state cache into the layer so it survives across
 	// builds. The app is not expected to commit .yarn/install-state.gz.
@@ -169,14 +172,11 @@ func (ip BerryInstallProcess) Execute(workingDir, modulesLayerPath string, launc
 		execArgs = []string{yarnBin, "install", "--immutable"}
 		ip.logger.Subprocess("Running 'node %s install --immutable' (app-provided yarnPath)", yarnBin)
 	} else {
-		// Use the buildpack-delivered Berry; suppress any residual yarnPath.
-		environment = append(environment, "YARN_IGNORE_PATH=1")
 		exe = ip.yarnExecutable
 		execArgs = []string{"install", "--immutable"}
 		ip.logger.Subprocess("Running 'yarn install --immutable' (buildpack-provided Berry)")
 	}
 
-	buffer := bytes.NewBuffer(nil)
 	err = exe.Execute(pexec.Execution{
 		Args:   execArgs,
 		Env:    environment,
@@ -185,7 +185,7 @@ func (ip BerryInstallProcess) Execute(workingDir, modulesLayerPath string, launc
 		Dir:    workingDir,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to execute yarn install: %w\n%s", err, buffer.String())
+		return fmt.Errorf("failed to execute yarn install: %w", err)
 	}
 
 	// Move node_modules from working directory into the layer so the layer can

--- a/berry_install_process.go
+++ b/berry_install_process.go
@@ -47,7 +47,7 @@ func yarnPathFromRC(workingDir string) (string, error) {
 		}
 		return "", fmt.Errorf("failed to open .yarnrc.yml: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/berry_install_process.go
+++ b/berry_install_process.go
@@ -77,12 +77,32 @@ func (ip BerryInstallProcess) ShouldRun(workingDir string, metadata map[string]i
 }
 
 func (ip BerryInstallProcess) SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath string) (string, error) {
+	appNodeModules := filepath.Join(workingDir, "node_modules")
+	layerNodeModules := filepath.Join(nextModulesLayerPath, "node_modules")
+
+	// remove any prior symlink. RemoveAll function, in case of a symlink, only unlinks the path.
+	if err := os.RemoveAll(appNodeModules); err != nil {
+		return "", fmt.Errorf("failed to clear node_modules in working directory: %w", err)
+	}
+
+	// If the node_modules directory is not empty, means that probably the build if statement ran.
+	// In that case, we want to reuse the node_modules directory from the build if statement.
 	if currentModulesLayerPath != "" {
-		err := fs.Copy(filepath.Join(currentModulesLayerPath, "node_modules"), filepath.Join(nextModulesLayerPath, "node_modules"))
+		err := fs.Copy(filepath.Join(currentModulesLayerPath, "node_modules"), layerNodeModules)
 		if err != nil {
 			return "", fmt.Errorf("failed to copy node_modules directory: %w", err)
 		}
+	} else {
+		if err := os.MkdirAll(layerNodeModules, os.ModePerm); err != nil {
+			return "", fmt.Errorf("failed to create node_modules in layer: %w", err)
+		}
 	}
+
+	// Point the app at this layer so yarn install writes into the correct place.
+	if err := os.Symlink(layerNodeModules, appNodeModules); err != nil {
+		return "", fmt.Errorf("failed to symlink node_modules to layer: %w", err)
+	}
+
 	return nextModulesLayerPath, nil
 }
 
@@ -92,11 +112,12 @@ func (ip BerryInstallProcess) SetupModules(workingDir, currentModulesLayerPath, 
 // binary, that binary is invoked via `node <yarnPath>` — giving the app full
 // control over the Berry version. Otherwise the buildpack-delivered Berry
 // (on PATH as `yarn`) is used.
+//
+// SetupModules must be called first for pointing the node_modules directory at the correct layer.
 func (ip BerryInstallProcess) Execute(workingDir, modulesLayerPath string, launch bool) error {
 	environment := os.Environ()
 
-	// Redirect Berry's install-state cache into the layer so it survives across
-	// builds. The app is not expected to commit .yarn/install-state.gz.
+	// Keep install-state.gz in the layer instead of the app directory as it is not expected to be committed.
 	installStateDir := filepath.Join(modulesLayerPath, ".yarn")
 	if err := os.MkdirAll(installStateDir, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create install-state directory in layer: %w", err)
@@ -138,12 +159,15 @@ func (ip BerryInstallProcess) Execute(workingDir, modulesLayerPath string, launc
 		return fmt.Errorf("failed to execute yarn install: %w", err)
 	}
 
-	// Move node_modules from working directory into the layer so the layer can
-	// be cached and reused across builds.
-	srcNodeModules := filepath.Join(workingDir, "node_modules")
-	dstNodeModules := filepath.Join(modulesLayerPath, "node_modules")
-	if info, statErr := os.Lstat(srcNodeModules); statErr == nil && info.IsDir() {
-		if err := fs.Move(srcNodeModules, dstNodeModules); err != nil {
+	// If yarn replaced the symlink with a real directory, move it into the layer.
+	appNodeModules := filepath.Join(workingDir, "node_modules")
+	layerNodeModules := filepath.Join(modulesLayerPath, "node_modules")
+	info, statErr := os.Lstat(appNodeModules)
+	if statErr == nil && info.Mode()&os.ModeSymlink == 0 && info.IsDir() {
+		if err := os.RemoveAll(layerNodeModules); err != nil {
+			return fmt.Errorf("failed to clear layer node_modules: %w", err)
+		}
+		if err := fs.Move(appNodeModules, layerNodeModules); err != nil {
 			return fmt.Errorf("failed to move node_modules into layer: %w", err)
 		}
 	}

--- a/berry_install_process.go
+++ b/berry_install_process.go
@@ -71,58 +71,9 @@ func yarnPathFromRC(workingDir string) (string, error) {
 }
 
 func (ip BerryInstallProcess) ShouldRun(workingDir string, metadata map[string]interface{}) (run bool, sha string, err error) {
-	ip.logger.Subprocess("Process inputs:")
-
-	_, err = os.Stat(filepath.Join(workingDir, "yarn.lock"))
-	if os.IsNotExist(err) {
-		ip.logger.Action("yarn.lock -> Not found")
-		ip.logger.Break()
-		return true, "", nil
-	} else if err != nil {
-		return true, "", fmt.Errorf("unable to read yarn.lock file: %w", err)
-	}
-
-	ip.logger.Action("yarn.lock -> Found")
-	ip.logger.Break()
-
-	nodeEnv := os.Getenv("NODE_ENV")
-
-	file, err := os.CreateTemp("", "berry-node-env-*")
-	if err != nil {
-		return true, "", fmt.Errorf("failed to create temp file: %w", err)
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("failed to close temp file: %w", closeErr)
-		}
-	}()
-
-	if _, writeErr := file.WriteString(nodeEnv); writeErr != nil {
-		return true, "", fmt.Errorf("failed to write temp file: %w", writeErr)
-	}
-
-	pathsToSum := []string{
-		filepath.Join(workingDir, "yarn.lock"),
-		filepath.Join(workingDir, "package.json"),
-		file.Name(),
-	}
-	for _, optional := range []string{".yarnrc.yml", ".pnp.cjs", "pnp.loader.mjs"} {
-		p := filepath.Join(workingDir, optional)
-		if _, statErr := os.Stat(p); statErr == nil {
-			pathsToSum = append(pathsToSum, p)
-		}
-	}
-	sum, err := ip.summer.Sum(pathsToSum...)
-	if err != nil {
-		return true, "", fmt.Errorf("unable to sum config files: %w", err)
-	}
-
-	prevSHA, ok := metadata["cache_sha"].(string)
-	if (ok && sum != prevSHA) || !ok {
-		return true, sum, nil
-	}
-
-	return false, "", nil
+	return shouldRun(workingDir, metadata, ip.summer, ip.logger, func() ([]byte, error) {
+		return []byte(os.Getenv("NODE_ENV")), nil
+	}, []string{".yarnrc.yml", ".pnp.cjs", "pnp.loader.mjs"})
 }
 
 func (ip BerryInstallProcess) SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath string) (string, error) {

--- a/berry_install_process.go
+++ b/berry_install_process.go
@@ -91,8 +91,7 @@ func (ip BerryInstallProcess) SetupModules(workingDir, currentModulesLayerPath, 
 // If the app declares yarnPath in .yarnrc.yml pointing to a committed .cjs
 // binary, that binary is invoked via `node <yarnPath>` — giving the app full
 // control over the Berry version. Otherwise the buildpack-delivered Berry
-// (on PATH as `yarn`) is used with YARN_IGNORE_PATH=1 to prevent any stale
-// yarnPath from interfering.
+// (on PATH as `yarn`) is used.
 func (ip BerryInstallProcess) Execute(workingDir, modulesLayerPath string, launch bool) error {
 	environment := os.Environ()
 

--- a/berry_install_process_test.go
+++ b/berry_install_process_test.go
@@ -1,0 +1,399 @@
+package yarninstall_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/v2/pexec"
+	"github.com/paketo-buildpacks/packit/v2/scribe"
+	yarninstall "github.com/paketo-buildpacks/yarn-install"
+	"github.com/paketo-buildpacks/yarn-install/fakes"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testBerryInstallProcess(t *testing.T, context spec.G, it spec.S) {
+	var Expect = NewWithT(t).Expect
+
+	context("ShouldRun", func() {
+		var (
+			workingDir     string
+			executable     *fakes.Executable
+			summer         *fakes.Summer
+			buffer         *bytes.Buffer
+			installProcess yarninstall.BerryInstallProcess
+		)
+
+		it.Before(func() {
+			var err error
+			workingDir, err = os.MkdirTemp("", "working-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			executable = &fakes.Executable{}
+			summer = &fakes.Summer{}
+			buffer = bytes.NewBuffer(nil)
+
+			installProcess = yarninstall.NewBerryInstallProcess(executable, &fakes.Executable{}, summer, scribe.NewEmitter(buffer))
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(workingDir)).To(Succeed())
+		})
+
+		context("when yarn.lock does not exist", func() {
+			it("returns run=true with empty sha", func() {
+				run, sha, err := installProcess.ShouldRun(workingDir, map[string]interface{}{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(run).To(BeTrue())
+				Expect(sha).To(Equal(""))
+			})
+		})
+
+		context("when yarn.lock exists and sha has changed", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(workingDir, "yarn.lock"), []byte(""), os.ModePerm)).To(Succeed())
+				summer.SumCall.Stub = func(...string) (string, error) {
+					return "new-sha", nil
+				}
+			})
+
+			it("returns run=true with new sha", func() {
+				run, sha, err := installProcess.ShouldRun(workingDir, map[string]interface{}{
+					"cache_sha": "old-sha",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(run).To(BeTrue())
+				Expect(sha).To(Equal("new-sha"))
+				// Should sum yarn.lock, package.json and a temp env file
+				Expect(summer.SumCall.Receives.Paths[0]).To(Equal(filepath.Join(workingDir, "yarn.lock")))
+				Expect(summer.SumCall.Receives.Paths[1]).To(Equal(filepath.Join(workingDir, "package.json")))
+			})
+		})
+
+		context("when yarn.lock exists and sha matches", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(workingDir, "yarn.lock"), []byte(""), os.ModePerm)).To(Succeed())
+				summer.SumCall.Stub = func(...string) (string, error) {
+					return "same-sha", nil
+				}
+			})
+
+			it("returns run=false", func() {
+				run, sha, err := installProcess.ShouldRun(workingDir, map[string]interface{}{
+					"cache_sha": "same-sha",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(run).To(BeFalse())
+				Expect(sha).To(Equal(""))
+			})
+		})
+
+		context("when cache_sha metadata is missing (first run)", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(workingDir, "yarn.lock"), []byte(""), os.ModePerm)).To(Succeed())
+				summer.SumCall.Stub = func(...string) (string, error) {
+					return "first-sha", nil
+				}
+			})
+
+			it("returns run=true", func() {
+				run, sha, err := installProcess.ShouldRun(workingDir, map[string]interface{}{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(run).To(BeTrue())
+				Expect(sha).To(Equal("first-sha"))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when working dir is unreadable", func() {
+				it.Before(func() {
+					Expect(os.Chmod(workingDir, 0000)).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Chmod(workingDir, os.ModePerm)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, _, err := installProcess.ShouldRun(workingDir, map[string]interface{}{})
+					Expect(err).To(MatchError(ContainSubstring("unable to read yarn.lock file:")))
+				})
+			})
+
+			context("when summer fails", func() {
+				it.Before(func() {
+					Expect(os.WriteFile(filepath.Join(workingDir, "yarn.lock"), []byte(""), os.ModePerm)).To(Succeed())
+					summer.SumCall.Stub = func(...string) (string, error) {
+						return "", errors.New("sum failed")
+					}
+				})
+
+				it("returns an error", func() {
+					_, _, err := installProcess.ShouldRun(workingDir, map[string]interface{}{})
+					Expect(err).To(MatchError(ContainSubstring("unable to sum config files:")))
+				})
+			})
+		})
+	})
+
+	context("SetupModules", func() {
+		var (
+			workingDir              string
+			currentModulesLayerPath string
+			nextModulesLayerPath    string
+			installProcess          yarninstall.BerryInstallProcess
+		)
+
+		it.Before(func() {
+			var err error
+			workingDir, err = os.MkdirTemp("", "working-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			currentModulesLayerPath, err = os.MkdirTemp("", "current-modules-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			nextModulesLayerPath, err = os.MkdirTemp("", "next-modules-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			installProcess = yarninstall.NewBerryInstallProcess(&fakes.Executable{}, &fakes.Executable{}, &fakes.Summer{}, scribe.NewEmitter(bytes.NewBuffer(nil)))
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(workingDir)).To(Succeed())
+			Expect(os.RemoveAll(currentModulesLayerPath)).To(Succeed())
+			Expect(os.RemoveAll(nextModulesLayerPath)).To(Succeed())
+		})
+
+		context("when currentModulesLayerPath is empty (first run)", func() {
+			it("creates node_modules in next layer and returns the layer path", func() {
+				nextPath, err := installProcess.SetupModules(workingDir, "", nextModulesLayerPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nextPath).To(Equal(nextModulesLayerPath))
+				Expect(filepath.Join(nextModulesLayerPath, "node_modules")).To(BeADirectory())
+			})
+		})
+
+		context("when currentModulesLayerPath is set (cached layer)", func() {
+			it.Before(func() {
+				Expect(os.MkdirAll(filepath.Join(currentModulesLayerPath, "node_modules"), os.ModePerm)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(currentModulesLayerPath, "node_modules", "cached-pkg"), []byte(""), os.ModePerm)).To(Succeed())
+			})
+
+			it("copies node_modules from current layer into next layer", func() {
+				nextPath, err := installProcess.SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nextPath).To(Equal(nextModulesLayerPath))
+				Expect(filepath.Join(nextModulesLayerPath, "node_modules", "cached-pkg")).To(BeAnExistingFile())
+			})
+		})
+
+		context("failure cases", func() {
+			context("when copying from current layer fails", func() {
+				it.Before(func() {
+					Expect(os.Chmod(currentModulesLayerPath, 0444)).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Chmod(currentModulesLayerPath, os.ModePerm)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := installProcess.SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath)
+					Expect(err).To(MatchError(ContainSubstring("failed to copy node_modules directory:")))
+				})
+			})
+		})
+	})
+
+	context("Execute", func() {
+		var (
+			workingDir       string
+			modulesLayerPath string
+			executions       []pexec.Execution
+			buffer           *bytes.Buffer
+			executable       *fakes.Executable
+			installProcess   yarninstall.BerryInstallProcess
+		)
+
+		it.Before(func() {
+			var err error
+			workingDir, err = os.MkdirTemp("", "working-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			modulesLayerPath, err = os.MkdirTemp("", "modules-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			buffer = bytes.NewBuffer(nil)
+			executions = []pexec.Execution{}
+			executable = &fakes.Executable{}
+			executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+				executions = append(executions, execution)
+				fmt.Fprintln(execution.Stdout, "stdout output")
+				fmt.Fprintln(execution.Stderr, "stderr output")
+				return nil
+			}
+
+			installProcess = yarninstall.NewBerryInstallProcess(executable, &fakes.Executable{}, &fakes.Summer{}, scribe.NewEmitter(buffer))
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(workingDir)).To(Succeed())
+			Expect(os.RemoveAll(modulesLayerPath)).To(Succeed())
+		})
+
+		context("when no yarnPath in .yarnrc.yml (buildpack-provided Berry)", func() {
+			context("when launch is false", func() {
+				it("runs yarn install --immutable with YARN_IGNORE_PATH and NODE_ENV=development", func() {
+					err := installProcess.Execute(workingDir, modulesLayerPath, false)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(executions).To(HaveLen(1))
+					Expect(executions[0].Args).To(Equal([]string{"install", "--immutable"}))
+					Expect(executions[0].Dir).To(Equal(workingDir))
+					Expect(executions[0].Env).To(ContainElement("YARN_IGNORE_PATH=1"))
+					Expect(executions[0].Env).To(ContainElement("YARN_NODE_LINKER=node-modules"))
+					Expect(executions[0].Env).To(ContainElement("NODE_ENV=development"))
+					Expect(executions[0].Env).To(ContainElement(ContainSubstring("YARN_INSTALL_STATE_PATH=")))
+
+					Expect(buffer.String()).To(ContainSubstring("buildpack-provided Berry"))
+				})
+			})
+
+			context("when launch is true", func() {
+				it("runs yarn install --immutable without overriding NODE_ENV", func() {
+					err := installProcess.Execute(workingDir, modulesLayerPath, true)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(executions).To(HaveLen(1))
+					Expect(executions[0].Args).To(Equal([]string{"install", "--immutable"}))
+					Expect(executions[0].Env).To(ContainElement("YARN_IGNORE_PATH=1"))
+					Expect(executions[0].Env).To(ContainElement("YARN_NODE_LINKER=node-modules"))
+					Expect(executions[0].Env).NotTo(ContainElement("NODE_ENV=development"))
+				})
+			})
+		})
+
+		context("when app provides yarnPath in .yarnrc.yml", func() {
+			var nodeExecutable *fakes.Executable
+			var nodeExecutions []pexec.Execution
+
+			it.Before(func() {
+				// Create a fake committed Berry binary.
+				Expect(os.MkdirAll(filepath.Join(workingDir, ".yarn", "releases"), os.ModePerm)).To(Succeed())
+				Expect(os.WriteFile(
+					filepath.Join(workingDir, ".yarn", "releases", "yarn-4.12.0.cjs"),
+					[]byte("// fake berry"), os.ModePerm,
+				)).To(Succeed())
+				Expect(os.WriteFile(
+					filepath.Join(workingDir, ".yarnrc.yml"),
+					[]byte("yarnPath: .yarn/releases/yarn-4.12.0.cjs\nnodeLinker: node-modules\n"),
+					os.ModePerm,
+				)).To(Succeed())
+
+				nodeExecutions = []pexec.Execution{}
+				nodeExecutable = &fakes.Executable{}
+				nodeExecutable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+					nodeExecutions = append(nodeExecutions, execution)
+					return nil
+				}
+				installProcess = yarninstall.NewBerryInstallProcess(executable, nodeExecutable, &fakes.Summer{}, scribe.NewEmitter(buffer))
+			})
+
+			it("invokes node <yarnPath> install --immutable and does not set YARN_IGNORE_PATH", func() {
+				err := installProcess.Execute(workingDir, modulesLayerPath, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				// yarn executable must NOT be called.
+				Expect(executions).To(HaveLen(0))
+				// node executable IS called.
+				Expect(nodeExecutions).To(HaveLen(1))
+				expectedBin := filepath.Join(workingDir, ".yarn", "releases", "yarn-4.12.0.cjs")
+				Expect(nodeExecutions[0].Args).To(Equal([]string{expectedBin, "install", "--immutable"}))
+				Expect(nodeExecutions[0].Env).NotTo(ContainElement("YARN_IGNORE_PATH=1"))
+				Expect(nodeExecutions[0].Env).To(ContainElement("YARN_NODE_LINKER=node-modules"))
+				Expect(nodeExecutions[0].Env).To(ContainElement("NODE_ENV=development"))
+				Expect(buffer.String()).To(ContainSubstring("app-provided yarnPath"))
+			})
+		})
+
+		context("when yarn install places node_modules in the working dir", func() {
+			it.Before(func() {
+				executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+					executions = append(executions, execution)
+					// Simulate berry creating node_modules in workingDir
+					Expect(os.MkdirAll(filepath.Join(workingDir, "node_modules", "some-pkg"), os.ModePerm)).To(Succeed())
+					return nil
+				}
+			})
+
+			it("moves node_modules into the layer", func() {
+				err := installProcess.Execute(workingDir, modulesLayerPath, true)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(filepath.Join(workingDir, "node_modules")).NotTo(BeADirectory())
+				Expect(filepath.Join(modulesLayerPath, "node_modules", "some-pkg")).To(BeADirectory())
+			})
+		})
+
+		context("failure cases", func() {
+			context("when the yarn executable fails", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+						return errors.New("yarn berry install failed")
+					}
+				})
+
+				it("returns an error", func() {
+					err := installProcess.Execute(workingDir, modulesLayerPath, true)
+					Expect(err).To(MatchError(ContainSubstring("failed to execute yarn install:")))
+					Expect(err).To(MatchError(ContainSubstring("yarn berry install failed")))
+				})
+			})
+		})
+	})
+
+	context("environment variable integration (NODE_ENV)", func() {
+		var (
+			workingDir       string
+			modulesLayerPath string
+			executions       []pexec.Execution
+			installProcess   yarninstall.BerryInstallProcess
+		)
+
+		it.Before(func() {
+			var err error
+			workingDir, err = os.MkdirTemp("", "working-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			modulesLayerPath, err = os.MkdirTemp("", "modules-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			executions = []pexec.Execution{}
+			exe := &fakes.Executable{}
+			exe.ExecuteCall.Stub = func(e pexec.Execution) error {
+				executions = append(executions, e)
+				return nil
+			}
+			installProcess = yarninstall.NewBerryInstallProcess(exe, &fakes.Executable{}, &fakes.Summer{}, scribe.NewEmitter(bytes.NewBuffer(nil)))
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(workingDir)).To(Succeed())
+			Expect(os.RemoveAll(modulesLayerPath)).To(Succeed())
+		})
+
+		it("does not have --frozen-lockfile, --ignore-engines, or --production", func() {
+			err := installProcess.Execute(workingDir, modulesLayerPath, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Join(executions[0].Args, " ")).NotTo(ContainSubstring("frozen-lockfile"))
+			Expect(strings.Join(executions[0].Args, " ")).NotTo(ContainSubstring("ignore-engines"))
+			Expect(strings.Join(executions[0].Args, " ")).NotTo(ContainSubstring("production"))
+		})
+	})
+}

--- a/berry_install_process_test.go
+++ b/berry_install_process_test.go
@@ -171,11 +171,10 @@ func testBerryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when currentModulesLayerPath is empty (first run)", func() {
-			it("creates node_modules in next layer and returns the layer path", func() {
+			it("returns the next layer path without pre-creating node_modules", func() {
 				nextPath, err := installProcess.SetupModules(workingDir, "", nextModulesLayerPath)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(nextPath).To(Equal(nextModulesLayerPath))
-				Expect(filepath.Join(nextModulesLayerPath, "node_modules")).To(BeADirectory())
 			})
 		})
 
@@ -249,15 +248,15 @@ func testBerryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 
 		context("when no yarnPath in .yarnrc.yml (buildpack-provided Berry)", func() {
 			context("when launch is false", func() {
-				it("runs yarn install --immutable with YARN_IGNORE_PATH and NODE_ENV=development", func() {
+				it("runs yarn install --immutable with NODE_ENV=development", func() {
 					err := installProcess.Execute(workingDir, modulesLayerPath, false)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(executions).To(HaveLen(1))
 					Expect(executions[0].Args).To(Equal([]string{"install", "--immutable"}))
 					Expect(executions[0].Dir).To(Equal(workingDir))
-					Expect(executions[0].Env).To(ContainElement("YARN_IGNORE_PATH=1"))
-					Expect(executions[0].Env).To(ContainElement("YARN_NODE_LINKER=node-modules"))
+					Expect(executions[0].Env).NotTo(ContainElement("YARN_IGNORE_PATH=1"))
+					Expect(executions[0].Env).NotTo(ContainElement("YARN_NODE_LINKER=node-modules"))
 					Expect(executions[0].Env).To(ContainElement("NODE_ENV=development"))
 					Expect(executions[0].Env).To(ContainElement(ContainSubstring("YARN_INSTALL_STATE_PATH=")))
 
@@ -272,8 +271,8 @@ func testBerryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 
 					Expect(executions).To(HaveLen(1))
 					Expect(executions[0].Args).To(Equal([]string{"install", "--immutable"}))
-					Expect(executions[0].Env).To(ContainElement("YARN_IGNORE_PATH=1"))
-					Expect(executions[0].Env).To(ContainElement("YARN_NODE_LINKER=node-modules"))
+					Expect(executions[0].Env).NotTo(ContainElement("YARN_IGNORE_PATH=1"))
+					Expect(executions[0].Env).NotTo(ContainElement("YARN_NODE_LINKER=node-modules"))
 					Expect(executions[0].Env).NotTo(ContainElement("NODE_ENV=development"))
 				})
 			})
@@ -316,7 +315,7 @@ func testBerryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 				expectedBin := filepath.Join(workingDir, ".yarn", "releases", "yarn-4.12.0.cjs")
 				Expect(nodeExecutions[0].Args).To(Equal([]string{expectedBin, "install", "--immutable"}))
 				Expect(nodeExecutions[0].Env).NotTo(ContainElement("YARN_IGNORE_PATH=1"))
-				Expect(nodeExecutions[0].Env).To(ContainElement("YARN_NODE_LINKER=node-modules"))
+				Expect(nodeExecutions[0].Env).NotTo(ContainElement("YARN_NODE_LINKER=node-modules"))
 				Expect(nodeExecutions[0].Env).To(ContainElement("NODE_ENV=development"))
 				Expect(buffer.String()).To(ContainSubstring("app-provided yarnPath"))
 			})

--- a/berry_install_process_test.go
+++ b/berry_install_process_test.go
@@ -171,24 +171,66 @@ func testBerryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when currentModulesLayerPath is empty (first run)", func() {
-			it("returns the next layer path without pre-creating node_modules", func() {
+			it("creates an empty layer node_modules and symlinks the working dir to it", func() {
 				nextPath, err := installProcess.SetupModules(workingDir, "", nextModulesLayerPath)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(nextPath).To(Equal(nextModulesLayerPath))
+
+				Expect(filepath.Join(nextModulesLayerPath, "node_modules")).To(BeADirectory())
+				info, err := os.Lstat(filepath.Join(workingDir, "node_modules"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(info.Mode() & os.ModeSymlink).NotTo(BeZero())
+				Expect(os.Readlink(filepath.Join(workingDir, "node_modules"))).To(Equal(filepath.Join(nextModulesLayerPath, "node_modules")))
 			})
 		})
 
-		context("when currentModulesLayerPath is set (cached layer)", func() {
+		context("when currentModulesLayerPath is set (warm-start from previous layer)", func() {
 			it.Before(func() {
 				Expect(os.MkdirAll(filepath.Join(currentModulesLayerPath, "node_modules"), os.ModePerm)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(currentModulesLayerPath, "node_modules", "cached-pkg"), []byte(""), os.ModePerm)).To(Succeed())
 			})
 
-			it("copies node_modules from current layer into next layer", func() {
+			it("copies node_modules into the next layer and symlinks the working dir to it", func() {
 				nextPath, err := installProcess.SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(nextPath).To(Equal(nextModulesLayerPath))
+
 				Expect(filepath.Join(nextModulesLayerPath, "node_modules", "cached-pkg")).To(BeAnExistingFile())
+				Expect(os.Readlink(filepath.Join(workingDir, "node_modules"))).To(Equal(filepath.Join(nextModulesLayerPath, "node_modules")))
+			})
+		})
+
+		context("when working dir node_modules is a symlink to another layer", func() {
+			var otherLayerPath string
+
+			it.Before(func() {
+				var err error
+				otherLayerPath, err = os.MkdirTemp("", "other-modules-dir")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(os.MkdirAll(filepath.Join(otherLayerPath, "node_modules", "stale-pkg"), os.ModePerm)).To(Succeed())
+				Expect(os.Symlink(
+					filepath.Join(otherLayerPath, "node_modules"),
+					filepath.Join(workingDir, "node_modules"),
+				)).To(Succeed())
+
+				Expect(os.MkdirAll(filepath.Join(currentModulesLayerPath, "node_modules"), os.ModePerm)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(currentModulesLayerPath, "node_modules", "cached-pkg"), []byte(""), os.ModePerm)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.RemoveAll(otherLayerPath)).To(Succeed())
+			})
+
+			it("retargets the working dir at the next layer, warm-starts from current, and leaves the other layer alone", func() {
+				nextPath, err := installProcess.SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nextPath).To(Equal(nextModulesLayerPath))
+
+				Expect(os.Readlink(filepath.Join(workingDir, "node_modules"))).To(Equal(filepath.Join(nextModulesLayerPath, "node_modules")))
+				Expect(filepath.Join(nextModulesLayerPath, "node_modules", "cached-pkg")).To(BeAnExistingFile())
+				Expect(filepath.Join(otherLayerPath, "node_modules", "stale-pkg")).To(BeADirectory())
+				Expect(filepath.Join(otherLayerPath, "node_modules", "cached-pkg")).NotTo(BeAnExistingFile())
 			})
 		})
 
@@ -323,9 +365,35 @@ func testBerryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 
 		context("when yarn install places node_modules in the working dir", func() {
 			it.Before(func() {
+				_, err := installProcess.SetupModules(workingDir, "", modulesLayerPath)
+				Expect(err).NotTo(HaveOccurred())
+
 				executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
 					executions = append(executions, execution)
-					// Simulate berry creating node_modules in workingDir
+					Expect(os.MkdirAll(filepath.Join(workingDir, "node_modules", "some-pkg"), os.ModePerm)).To(Succeed())
+					return nil
+				}
+			})
+
+			it("installs node_modules into the layer via symlink", func() {
+				err := installProcess.Execute(workingDir, modulesLayerPath, true)
+				Expect(err).NotTo(HaveOccurred())
+
+				info, err := os.Lstat(filepath.Join(workingDir, "node_modules"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(info.Mode() & os.ModeSymlink).NotTo(BeZero())
+				Expect(filepath.Join(modulesLayerPath, "node_modules", "some-pkg")).To(BeADirectory())
+			})
+		})
+
+		context("when yarn replaces the symlink with a real node_modules directory", func() {
+			it.Before(func() {
+				_, err := installProcess.SetupModules(workingDir, "", modulesLayerPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+					executions = append(executions, execution)
+					Expect(os.RemoveAll(filepath.Join(workingDir, "node_modules"))).To(Succeed())
 					Expect(os.MkdirAll(filepath.Join(workingDir, "node_modules", "some-pkg"), os.ModePerm)).To(Succeed())
 					return nil
 				}

--- a/berry_install_process_test.go
+++ b/berry_install_process_test.go
@@ -275,8 +275,10 @@ func testBerryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 			executable = &fakes.Executable{}
 			executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
 				executions = append(executions, execution)
-				fmt.Fprintln(execution.Stdout, "stdout output")
-				fmt.Fprintln(execution.Stderr, "stderr output")
+				_, err := fmt.Fprintln(execution.Stdout, "stdout output")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = fmt.Fprintln(execution.Stderr, "stderr output")
+				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
 

--- a/build.go
+++ b/build.go
@@ -42,7 +42,7 @@ type ConfigurationManager interface {
 	DeterminePath(typ, platformDir, entry string) (path string, err error)
 }
 
-func Build( entryResolver EntryResolver,
+func Build(entryResolver EntryResolver,
 	configurationManager ConfigurationManager,
 	homeDir string,
 	symlinker SymlinkManager,
@@ -175,6 +175,7 @@ func Build( entryResolver EntryResolver,
 				if err != nil {
 					return packit.BuildResult{}, err
 				}
+				currentModLayer = layer.Path
 			}
 
 			layer.Build = true
@@ -223,6 +224,11 @@ func Build( entryResolver EntryResolver,
 
 				if !build {
 					err = ensureNodeModulesSymlink(projectPath, layer.Path, tmpDir)
+					if err != nil {
+						return packit.BuildResult{}, err
+					}
+				} else if currentModLayer != "" {
+					err = ensureNodeModulesSymlink(projectPath, currentModLayer, tmpDir)
 					if err != nil {
 						return packit.BuildResult{}, err
 					}

--- a/build.go
+++ b/build.go
@@ -241,6 +241,9 @@ func Build(entryResolver EntryResolver,
 				path := filepath.Join(layer.Path, "node_modules", ".bin")
 				layer.LaunchEnv.Append("PATH", path, string(os.PathListSeparator))
 				layer.LaunchEnv.Default("NODE_PROJECT_PATH", projectPath)
+				if isBerryApp(projectPath) {
+					layer.LaunchEnv.Default("YARN_INSTALL_STATE_PATH", filepath.Join(layer.Path, ".yarn", "install-state.gz"))
+				}
 
 				logger.EnvironmentVariables(layer)
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -16,9 +16,9 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		filePath	  string
-		workingDir        string
-		detect            packit.DetectFunc
+		filePath   string
+		workingDir string
+		detect     packit.DetectFunc
 	)
 
 	it.Before(func() {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/onsi/gomega v1.42.1
 	github.com/paketo-buildpacks/libnodejs v0.4.3
 	github.com/paketo-buildpacks/occam v0.31.3
@@ -28,7 +29,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.59.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.59.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 // indirect
 	github.com/Microsoft/hcsshim v0.15.0-rc.3 // indirect

--- a/init_test.go
+++ b/init_test.go
@@ -10,10 +10,12 @@ import (
 func TestUnitYarn(t *testing.T) {
 	suite := spec.New("yarn", spec.Report(report.Terminal{}))
 	suite("Build", testBuild)
+	suite("BerryInstallProcess", testBerryInstallProcess)
 	suite("CacheHandler", testCacheHandler)
 	suite("Detect", testDetect)
 	suite("InstallProcess", testInstallProcess)
 	suite("PackageManagerConfigurationManager", testPackageManagerConfigurationManager)
+	suite("SwitchingInstallProcess", testSwitchingInstallProcess)
 	suite("Symlinker", testSymlinker)
 	suite.Run(t)
 }

--- a/install_process.go
+++ b/install_process.go
@@ -38,51 +38,68 @@ func NewYarnInstallProcess(executable Executable, summer Summer, logger scribe.E
 }
 
 func (ip YarnInstallProcess) ShouldRun(workingDir string, metadata map[string]interface{}) (run bool, sha string, err error) {
-	ip.logger.Subprocess("Process inputs:")
+	return shouldRun(workingDir, metadata, ip.summer, ip.logger, func() ([]byte, error) {
+		buffer := bytes.NewBuffer(nil)
+		if execErr := ip.executable.Execute(pexec.Execution{
+			Args:   []string{"config", "list", "--silent"},
+			Stdout: buffer,
+			Stderr: buffer,
+			Dir:    workingDir,
+		}); execErr != nil {
+			return nil, fmt.Errorf("failed to execute yarn config output:\n%s\nerror: %s", buffer.String(), execErr)
+		}
+		buffer.WriteString(os.Getenv("NODE_ENV"))
+		return buffer.Bytes(), nil
+	}, nil)
+}
+
+func shouldRun(workingDir string, metadata map[string]interface{}, summer Summer, logger scribe.Emitter, configContent func() ([]byte, error), optionalFiles []string) (run bool, sha string, err error) {
+	logger.Subprocess("Process inputs:")
 
 	_, err = os.Stat(filepath.Join(workingDir, "yarn.lock"))
 	if os.IsNotExist(err) {
-		ip.logger.Action("yarn.lock -> Not found")
-		ip.logger.Break()
+		logger.Action("yarn.lock -> Not found")
+		logger.Break()
 		return true, "", nil
 	} else if err != nil {
 		return true, "", fmt.Errorf("unable to read yarn.lock file: %w", err)
 	}
 
-	ip.logger.Action("yarn.lock -> Found")
-	ip.logger.Break()
+	logger.Action("yarn.lock -> Found")
+	logger.Break()
 
-	buffer := bytes.NewBuffer(nil)
-
-	err = ip.executable.Execute(pexec.Execution{
-		Args:   []string{"config", "list", "--silent"},
-		Stdout: buffer,
-		Stderr: buffer,
-		Dir:    workingDir,
-	})
+	content, err := configContent()
 	if err != nil {
-		return true, "", fmt.Errorf("failed to execute yarn config output:\n%s\nerror: %s", buffer.String(), err)
+		return true, "", err
 	}
-
-	nodeEnv := os.Getenv("NODE_ENV")
-	buffer.WriteString(nodeEnv)
 
 	file, err := os.CreateTemp("", "config-file")
 	if err != nil {
-		return true, "", fmt.Errorf("failed to create temp file for %s: %w", file.Name(), err)
+		return true, "", fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer func() {
-		if closeFileErr := file.Close(); closeFileErr != nil && err == nil {
-			err = fmt.Errorf("failed to close temp file: %w", closeFileErr)
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("failed to close temp file: %w", closeErr)
 		}
 	}()
 
-	_, err = file.Write(buffer.Bytes())
-	if err != nil {
-		return true, "", fmt.Errorf("failed to write temp file for %s: %w", file.Name(), err)
+	if _, writeErr := file.Write(content); writeErr != nil {
+		return true, "", fmt.Errorf("failed to write temp file: %w", writeErr)
 	}
 
-	sum, err := ip.summer.Sum(filepath.Join(workingDir, "yarn.lock"), filepath.Join(workingDir, "package.json"), file.Name())
+	pathsToSum := []string{
+		filepath.Join(workingDir, "yarn.lock"),
+		filepath.Join(workingDir, "package.json"),
+		file.Name(),
+	}
+	for _, optional := range optionalFiles {
+		p := filepath.Join(workingDir, optional)
+		if _, statErr := os.Stat(p); statErr == nil {
+			pathsToSum = append(pathsToSum, p)
+		}
+	}
+
+	sum, err := summer.Sum(pathsToSum...)
 	if err != nil {
 		return true, "", fmt.Errorf("unable to sum config files: %w", err)
 	}

--- a/run/main.go
+++ b/run/main.go
@@ -24,7 +24,14 @@ func (s SBOMGenerator) Generate(path string) (sbom.SBOM, error) {
 
 func main() {
 	logger := scribe.NewEmitter(os.Stdout).WithLevel(os.Getenv("BP_LOG_LEVEL"))
-	installProcess := yarninstall.NewYarnInstallProcess(pexec.NewExecutable("yarn"), fs.NewChecksumCalculator(), logger)
+	checksumCalculator := fs.NewChecksumCalculator()
+	yarnExecutable := pexec.NewExecutable("yarn")
+	nodeExecutable := pexec.NewExecutable("node")
+
+	classicProcess := yarninstall.NewYarnInstallProcess(yarnExecutable, checksumCalculator, logger)
+	berryProcess := yarninstall.NewBerryInstallProcess(yarnExecutable, nodeExecutable, checksumCalculator, logger)
+	installProcess := yarninstall.NewSwitchingInstallProcess(classicProcess, berryProcess)
+
 	sbomGenerator := SBOMGenerator{}
 	symlinker := yarninstall.NewSymlinker()
 	packageManagerConfigurationManager := yarninstall.NewPackageManagerConfigurationManager(servicebindings.NewResolver(), logger)

--- a/switching_install_process.go
+++ b/switching_install_process.go
@@ -1,0 +1,62 @@
+package yarninstall
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// isBerryApp returns true if the working directory's package.json declares a
+// "packageManager" field for Yarn 2+, e.g. "yarn@4.14.1".
+func isBerryApp(workingDir string) bool {
+	f, err := os.Open(filepath.Join(workingDir, "package.json"))
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	var pkg struct {
+		PackageManager string `json:"packageManager"`
+	}
+	if err := json.NewDecoder(f).Decode(&pkg); err != nil {
+		return false
+	}
+
+	if strings.HasPrefix(pkg.PackageManager, "yarn@") {
+		ver := strings.TrimPrefix(pkg.PackageManager, "yarn@")
+		major := strings.SplitN(ver, ".", 2)[0]
+		return major >= "2"
+	}
+	return false
+}
+
+// SwitchingInstallProcess selects between a classic and a berry install process
+// at runtime based on the app's package.json.
+type SwitchingInstallProcess struct {
+	classic InstallProcess
+	berry   InstallProcess
+}
+
+func NewSwitchingInstallProcess(classic, berry InstallProcess) SwitchingInstallProcess {
+	return SwitchingInstallProcess{classic: classic, berry: berry}
+}
+
+func (s SwitchingInstallProcess) ShouldRun(workingDir string, metadata map[string]interface{}) (bool, string, error) {
+	return s.resolve(workingDir).ShouldRun(workingDir, metadata)
+}
+
+func (s SwitchingInstallProcess) SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath string) (string, error) {
+	return s.resolve(workingDir).SetupModules(workingDir, currentModulesLayerPath, nextModulesLayerPath)
+}
+
+func (s SwitchingInstallProcess) Execute(workingDir, modulesLayerPath string, launch bool) error {
+	return s.resolve(workingDir).Execute(workingDir, modulesLayerPath, launch)
+}
+
+func (s SwitchingInstallProcess) resolve(workingDir string) InstallProcess {
+	if isBerryApp(workingDir) {
+		return s.berry
+	}
+	return s.classic
+}

--- a/switching_install_process.go
+++ b/switching_install_process.go
@@ -16,7 +16,7 @@ func isBerryApp(workingDir string) bool {
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var pkg struct {
 		PackageManager string `json:"packageManager"`

--- a/switching_install_process.go
+++ b/switching_install_process.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
 )
 
 // isBerryApp returns true if the working directory's package.json declares a
@@ -23,12 +25,16 @@ func isBerryApp(workingDir string) bool {
 		return false
 	}
 
-	if strings.HasPrefix(pkg.PackageManager, "yarn@") {
-		ver := strings.TrimPrefix(pkg.PackageManager, "yarn@")
-		major := strings.SplitN(ver, ".", 2)[0]
-		return major >= "2"
+	if !strings.HasPrefix(pkg.PackageManager, "yarn@") {
+		return false
 	}
-	return false
+
+	yarnVersion, err := semver.NewVersion(strings.TrimPrefix(pkg.PackageManager, "yarn@"))
+	if err != nil {
+		return false
+	}
+
+	return yarnVersion.GreaterThanEqual(semver.MustParse("2"))
 }
 
 // SwitchingInstallProcess selects between a classic and a berry install process

--- a/switching_install_process_test.go
+++ b/switching_install_process_test.go
@@ -1,0 +1,155 @@
+package yarninstall_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	yarninstall "github.com/paketo-buildpacks/yarn-install"
+	"github.com/paketo-buildpacks/yarn-install/fakes"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testSwitchingInstallProcess(t *testing.T, context spec.G, it spec.S) {
+	var Expect = NewWithT(t).Expect
+
+	var (
+		workingDir     string
+		classicProcess *fakes.InstallProcess
+		berryProcess   *fakes.InstallProcess
+		switching      yarninstall.SwitchingInstallProcess
+	)
+
+	it.Before(func() {
+		var err error
+		workingDir, err = os.MkdirTemp("", "working-dir")
+		Expect(err).NotTo(HaveOccurred())
+
+		classicProcess = &fakes.InstallProcess{}
+		berryProcess = &fakes.InstallProcess{}
+
+		switching = yarninstall.NewSwitchingInstallProcess(classicProcess, berryProcess)
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(workingDir)).To(Succeed())
+	})
+
+	context("when app has no packageManager field", func() {
+		it("delegates all methods to the classic process", func() {
+			classicProcess.ShouldRunCall.Returns.Run = true
+			classicProcess.ShouldRunCall.Returns.Sha = "classic-sha"
+
+			run, sha, err := switching.ShouldRun(workingDir, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(run).To(BeTrue())
+			Expect(sha).To(Equal("classic-sha"))
+			Expect(classicProcess.ShouldRunCall.CallCount).To(Equal(1))
+			Expect(berryProcess.ShouldRunCall.CallCount).To(Equal(0))
+
+			classicProcess.SetupModulesCall.Returns.String = "/modules"
+			nextPath, err := switching.SetupModules(workingDir, "", "/next")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nextPath).To(Equal("/modules"))
+			Expect(classicProcess.SetupModulesCall.CallCount).To(Equal(1))
+			Expect(berryProcess.SetupModulesCall.CallCount).To(Equal(0))
+
+			err = switching.Execute(workingDir, "/modules", true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(classicProcess.ExecuteCall.CallCount).To(Equal(1))
+			Expect(berryProcess.ExecuteCall.CallCount).To(Equal(0))
+		})
+	})
+
+	context("when app has packageManager yarn@1.22.22 (classic)", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "package.json"),
+				[]byte(`{"packageManager":"yarn@1.22.22"}`), os.ModePerm)).To(Succeed())
+		})
+
+		it("delegates to the classic process", func() {
+			_, _, err := switching.ShouldRun(workingDir, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(classicProcess.ShouldRunCall.CallCount).To(Equal(1))
+			Expect(berryProcess.ShouldRunCall.CallCount).To(Equal(0))
+		})
+	})
+
+	context("when app has packageManager yarn@4.14.1 (berry)", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "package.json"),
+				[]byte(`{"packageManager":"yarn@4.14.1"}`), os.ModePerm)).To(Succeed())
+		})
+
+		it("delegates ShouldRun to the berry process", func() {
+			berryProcess.ShouldRunCall.Returns.Run = true
+			berryProcess.ShouldRunCall.Returns.Sha = "berry-sha"
+
+			run, sha, err := switching.ShouldRun(workingDir, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(run).To(BeTrue())
+			Expect(sha).To(Equal("berry-sha"))
+			Expect(berryProcess.ShouldRunCall.CallCount).To(Equal(1))
+			Expect(classicProcess.ShouldRunCall.CallCount).To(Equal(0))
+		})
+
+		it("delegates SetupModules to the berry process", func() {
+			berryProcess.SetupModulesCall.Returns.String = "/berry-modules"
+			nextPath, err := switching.SetupModules(workingDir, "", "/next")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nextPath).To(Equal("/berry-modules"))
+			Expect(berryProcess.SetupModulesCall.CallCount).To(Equal(1))
+			Expect(classicProcess.SetupModulesCall.CallCount).To(Equal(0))
+		})
+
+		it("delegates Execute to the berry process", func() {
+			err := switching.Execute(workingDir, "/modules", true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(berryProcess.ExecuteCall.CallCount).To(Equal(1))
+			Expect(classicProcess.ExecuteCall.CallCount).To(Equal(0))
+		})
+	})
+
+	context("when app has packageManager yarn@2.x (berry threshold)", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "package.json"),
+				[]byte(`{"packageManager":"yarn@2.0.0"}`), os.ModePerm)).To(Succeed())
+		})
+
+		it("delegates to the berry process", func() {
+			_, _, err := switching.ShouldRun(workingDir, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(berryProcess.ShouldRunCall.CallCount).To(Equal(1))
+			Expect(classicProcess.ShouldRunCall.CallCount).To(Equal(0))
+		})
+	})
+
+	context("error propagation", func() {
+		context("when berry ShouldRun returns an error", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(workingDir, "package.json"),
+					[]byte(`{"packageManager":"yarn@4.0.0"}`), os.ModePerm)).To(Succeed())
+				berryProcess.ShouldRunCall.Returns.Err = errors.New("berry error")
+			})
+
+			it("returns the error", func() {
+				_, _, err := switching.ShouldRun(workingDir, nil)
+				Expect(err).To(MatchError("berry error"))
+			})
+		})
+
+		context("when classic Execute returns an error", func() {
+			it.Before(func() {
+				classicProcess.ExecuteCall.Returns.Error = errors.New("classic error")
+			})
+
+			it("returns the error", func() {
+				err := switching.Execute(workingDir, "/modules", true)
+				Expect(err).To(MatchError("classic error"))
+			})
+		})
+	})
+}

--- a/switching_install_process_test.go
+++ b/switching_install_process_test.go
@@ -2,6 +2,7 @@ package yarninstall_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -113,19 +114,29 @@ func testSwitchingInstallProcess(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	context("when app has packageManager yarn@2.x (berry threshold)", func() {
-		it.Before(func() {
-			Expect(os.WriteFile(filepath.Join(workingDir, "package.json"),
-				[]byte(`{"packageManager":"yarn@2.0.0"}`), os.ModePerm)).To(Succeed())
-		})
+	for _, tc := range []struct {
+		description    string
+		packageManager string
+	}{
+		{description: "yarn@2.x (berry threshold)", packageManager: "yarn@2.0.0"},
+		{description: "yarn@10.x (double-digit major)", packageManager: "yarn@10.0.0"},
+		{description: "Corepack build metadata", packageManager: "yarn@4.14.1+sha512.abcdef"},
+	} {
+		tc := tc
+		context(fmt.Sprintf("when app has packageManager %s", tc.description), func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(workingDir, "package.json"),
+					[]byte(fmt.Sprintf(`{"packageManager":%q}`, tc.packageManager)), os.ModePerm)).To(Succeed())
+			})
 
-		it("delegates to the berry process", func() {
-			_, _, err := switching.ShouldRun(workingDir, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(berryProcess.ShouldRunCall.CallCount).To(Equal(1))
-			Expect(classicProcess.ShouldRunCall.CallCount).To(Equal(0))
+			it("delegates to the berry process", func() {
+				_, _, err := switching.ShouldRun(workingDir, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(berryProcess.ShouldRunCall.CallCount).To(Equal(1))
+				Expect(classicProcess.ShouldRunCall.CallCount).To(Equal(0))
+			})
 		})
-	})
+	}
 
 	context("error propagation", func() {
 		context("when berry ShouldRun returns an error", func() {


### PR DESCRIPTION
### Summary

Adds support for Yarn Berry (v2+), removing the previous limitation of Classic-only installs. The install process is now selected automatically at runtime based on `packageManager` in `package.json`.

### Changes

- **`switching_install_process.go`** — New `SwitchingInstallProcess` that reads `packageManager` in `package.json` and delegates to either the Classic or Berry process. No changes to existing `YarnInstallProcess` logic.
- **`berry_install_process.go`** — New `BerryInstallProcess` implementing the `InstallProcess` interface:
  - Runs `yarn install --immutable` (Berry's equivalent of `--frozen-lockfile`)
  - Sets `YARN_NODE_LINKER=node-modules` for traditional `node_modules` layout
  - Redirects `install-state.gz` into the layer for caching across builds
  - Supports app-provided Berry binaries via `yarnPath` in `.yarnrc.yml` (invoked as `node <yarnPath> install --immutable`); falls back to buildpack-provided `yarn` with `YARN_IGNORE_PATH=1`
- **`run/main.go`** — Wires up both processes through `SwitchingInstallProcess`.
- **`README.md`** — Documents Classic vs Berry selection logic and `yarnPath` behaviour.

### Behaviour

| `packageManager` in `package.json` | Install command |
|---|---|
| `yarn@1.x.x` or absent | `yarn install --frozen-lockfile` (Classic) |
| `yarn@2.x.x` or higher | `yarn install --immutable` (Berry) |

### Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
